### PR TITLE
Fix amount of spaces used for the official hash

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
             <a name="sha1colors"></a><h3>SHA-1 COLORS</h3>
             <p>The official / standard colors for SHA are: </p>
             <pre>#c057d6 #086a9a #5b4ddb #2c7e52 #d39a49 #06b939 +2017</pre>
-            <p>This is the SHA-1 value of "SHA", 10036 spaces and "2017", the first hash that also ends in 2017.</p>
+            <p>This is the SHA-1 value of "SHA", 11061 spaces and "2017", the first hash that also ends in 2017.</p>
             <p>Text on the colors is always white. This has the best readability, by far.</p>
 
             <input style="color: white; background-color: #c057d6; width: 100px;" value="#c057d6"/>


### PR DESCRIPTION
To end up with the proper hash for the official SHA colours, you need 11061 spaces, not 10036.

This was tested with the following bash one-liner:
```bash
$ i=1; while [[ ! $(perl -e "print \"SHA\" . \" \" x $i . \"2017\"" | sha1sum) == *"2017  -" ]]; do ((i++)); done; echo $i
11061
```